### PR TITLE
Added .gitignore to application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+.DS_Store


### PR DESCRIPTION
This PR introduces a .gitignore file to ensure that unnecessary or sensitive files are not tracked in the repository for the Module Eighteen Challenge.